### PR TITLE
[Bug] 녹음파일 제목 수정 버그

### DIFF
--- a/src/dtos/recording.dto.js
+++ b/src/dtos/recording.dto.js
@@ -85,7 +85,7 @@ const renameMemoDto = (memo) => {
 const renameRecordingDto = (recording) => {
   return {
     message: "녹음파일 제목이 수정되었습니다.",
-    recording_id: recording.recording_id,
+    recording_id: recording.id,
     title: recording.title,
   };
 };


### PR DESCRIPTION
<img width="943" height="422" alt="image" src="https://github.com/user-attachments/assets/9fe047a1-79df-43f2-a9fc-e7f2e8918ff5" />

녹음파일 제목 수정 API에서 response로 recording_id도 반환하도록 수정함