### PR TITLE
[Bug] 내교수 리스트 조회 버그

### DIFF
--- a/src/dtos/professor.dto.js
+++ b/src/dtos/professor.dto.js
@@ -9,6 +9,7 @@ const professorListDto = (list) => {
 
 const professorMyListDto = (list) => {
   return list.map((item) => ({
+    professor_course_id: item.professor_course.id,
     professor_name: item.professor_course.professor.name,
     department: item.professor_course.professor.department,
     gender: item.professor_course.professor.gender,

--- a/src/repositories/professor.repository.js
+++ b/src/repositories/professor.repository.js
@@ -29,6 +29,7 @@ const findProfessorMy = async (user_id) => {
       select: {
         professor_course: {
           select: {
+            id: true,
             professor_id: true,
             professor: {
               select: {


### PR DESCRIPTION
<img width="953" height="556" alt="image" src="https://github.com/user-attachments/assets/02f9e6be-bb3f-4595-9724-f50c84dac11b" />

내교수 리스트 조회할때 response로 professor_course_id도 반환하도록 수정함

